### PR TITLE
Implement automatic crawler script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
-MONGO_URI=mongodb+srv://<user>:<pw>@cluster0.mongodb.net/guardian?retryWrites=true&w=majority
+MONGO_URI=mongodb+srv://Narion2025:<db_password>@cookieguard-crawler-clu.3v7jie9.mongodb.net/?retryWrites=true&w=majority&appName=CookieGuard-crawler-Cluster0
 PORT=4000
+DOMAINS=google.de,youtube.com,amazon.de,ebay.de,bild.de,spiegel.de,wikipedia.org,facebook.com,xhamster.com,pornhub.com,xvideos.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 .env
+dist/

--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ This service crawls a website, classifies cookies and scripts and stores results
 
 ### Batch scanning
 Run `npm run scan -- domain1.com domain2.com` to process multiple domains from the command line.
+
+### Automatic scanning
+Set `DOMAINS` in `.env` to a comma-separated list of domains and run `npm run auto` to crawl them sequentially.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "lint": "eslint .",
     "build": "tsc -p .",
     "start": "node dist/main.js",
-    "scan": "ts-node src/cli/scan.ts"
+    "scan": "node --loader ts-node/esm src/cli/scan.ts",
+    "auto": "node --loader ts-node/esm src/cli/auto.ts"
   },
   "dependencies": {
     "axios": "^1",

--- a/src/classifier/index.ts
+++ b/src/classifier/index.ts
@@ -1,7 +1,7 @@
-import type {Protocol} from 'puppeteer';
+import type {Cookie as PPCookie} from 'puppeteer';
 const red=/(_ga|_gid|fbp|fr|_gcl|doubleclick|adservice|adsense)/i;
 const yellow=/(matomo|mp_|mixpanel|segment|amplitude)/i;
-export function classifyCookie(c:Protocol.Network.Cookie){
+export function classifyCookie(c:PPCookie){
   if(red.test(c.name)||red.test(c.domain))return{category:'red' as const,purpose:'Tracking/Marketing'};
   if(yellow.test(c.name))return{category:'yellow' as const,purpose:'Analyse/Statistik'};
   return{category:'green' as const,purpose:'Essentiell'};

--- a/src/cli/auto.ts
+++ b/src/cli/auto.ts
@@ -1,0 +1,25 @@
+import { crawl } from '../crawler/index.js';
+import mongoose from 'mongoose';
+import 'dotenv/config';
+import { Evaluation } from '../models/Evaluation.js';
+
+async function run() {
+  const list = process.env.DOMAINS?.split(',').map(d => d.trim()).filter(Boolean);
+  if (!list || list.length === 0) {
+    throw new Error('No domains specified in DOMAINS env variable');
+  }
+
+  await mongoose.connect(process.env.MONGO_URI!);
+  for (const domain of list) {
+    console.log(`Scanning ${domain} ...`);
+    const res = await crawl(domain);
+    await Evaluation.create(res);
+    console.log(`${domain}: ${res.overallRating}`);
+  }
+  await mongoose.disconnect();
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,17 +1,30 @@
 import express from 'express';
 import dotenv from 'dotenv';
+import mongoose from 'mongoose';
+import {router as apiRouter} from './routes/api.js';
 
 dotenv.config();
 
-const app = express();
-app.use(express.json());
+async function bootstrap() {
+  await mongoose.connect(process.env.MONGO_URI as string);
+  console.log('✅ MongoDB connected');
 
-app.get('/', (_req, res) => {
-  res.send('CookieGuard API läuft 🎉');
-});
+  const app = express();
+  app.use(express.json());
 
-const PORT = process.env.PORT || 4000;
+  app.get('/', (_req, res) => {
+    res.send('CookieGuard API läuft 🎉');
+  });
 
-app.listen(PORT, () => {
-  console.log('✅ Server läuft auf http://localhost:' + PORT);
+  app.use('/v1', apiRouter);
+
+  const PORT = process.env.PORT || 4000;
+  app.listen(PORT, () => {
+    console.log('✅ Server läuft auf http://localhost:' + PORT);
+  });
+}
+
+bootstrap().catch((err) => {
+  console.error('Startup error:', err);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- add environment template for crawler to run on multiple domains
- document automatic crawl workflow in README
- add script for running sequential scans

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: missing script)*
- `npm run auto` *(fails: querySrv ENOTFOUND _mongodb._tcp.cookieguard-crawler-clu.3v7jie9.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_b_684494f213e08322938726597f7dd3a7